### PR TITLE
Change the result display when no dependencies are outdated.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"time"
@@ -30,9 +31,8 @@ func main() {
 	}
 
 	spin.Stop()
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Package", "Current", "Latest", "GoVersion"})
-	table.SetBorder(false)
+
+	var tableRows [][]string
 	for _, mod := range modules {
 		if mod.Update == nil {
 			continue
@@ -42,14 +42,23 @@ func main() {
 			continue
 		}
 
-		table.Append([]string{
+		tableRows = append(tableRows, []string{
 			mod.Path,
 			mod.Version,
 			mod.Update.Version,
 			mod.GoVersion,
 		})
 	}
-	table.Render()
+
+	if len(tableRows) == 0 {
+		fmt.Println("\U0001f4ab\033[1;32m Complete!\033[0m All of your dependencies are up to date.")
+	} else {
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetHeader([]string{"Package", "Current", "Latest", "GoVersion"})
+		table.SetBorder(false)
+		table.AppendBulk(tableRows)
+		table.Render()
+	}
 }
 
 // contains checks if str is in list.


### PR DESCRIPTION
输出的时候，当没有依赖项是需要更新的时候，光秃秃展示一个表头有点不美观😂.
<img width="492" alt="image" src="https://user-images.githubusercontent.com/28704977/170486476-0ef2accf-e519-4bfb-9c26-9e66eecdb3e2.png">

所以我想改一下逻辑，当没有更新的类目时候，输出个文案。
<img width="520" alt="image" src="https://user-images.githubusercontent.com/28704977/170486522-1ce0d5af-9a84-401f-abd4-9a5940f6239d.png">

大佬考虑一下如何? 😅